### PR TITLE
Stabilize test checking badge generation and skip windows incompatible tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,7 @@ def unit(session):
 
 @nox.session(python=['3.4', '3.5', '3.6', '3.7'])
 @nox.parametrize('install',
-                 ['Jinja2==2.9.0', 'Pillow==5.0.0', 'requests==2.9.0'])
+                 ['Jinja2==2.9.0', 'Pillow==5.0.0', 'requests==2.9.0', 'xmldiff==2.4'])
 def compatibility(session, install):
     """Run the unit test suite with each support library and Python version."""
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     extras_require={
         'pil-measurement': ['Pillow>=5,<6'],
         'dev': ['fonttools>=3.26', 'nox', 'Pillow>=5',
-                'pytest>=3.6'],
+                'pytest>=3.6', 'xmldiff>=2.4'],
     },
     license='Apache-2.0',
     packages=["pybadges"],

--- a/tests/test_pybadges.py
+++ b/tests/test_pybadges.py
@@ -21,6 +21,7 @@ import os.path
 import unittest
 import pathlib
 import tempfile
+import xmldiff.main
 
 import pybadges
 
@@ -53,11 +54,12 @@ class TestPybadgesBadge(unittest.TestCase):
             with self.subTest(example=file_name):
                 filepath = os.path.join(TEST_DIR, 'golden-images', file_name)
 
-                with open(filepath, 'r') as f:
+                with open(filepath, mode="r", encoding="utf-8") as f:
                     golden_image = f.read()
                 pybadge_image = pybadges.badge(**example)
-                self.assertEqual(golden_image, pybadge_image)
 
+                diff = xmldiff.main.diff_texts(golden_image, pybadge_image)
+                self.assertFalse(diff)
 
 class TestEmbedImage(unittest.TestCase):
     """Tests for pybadges._embed_image."""

--- a/tests/test_pybadges.py
+++ b/tests/test_pybadges.py
@@ -20,6 +20,7 @@ import json
 import os.path
 import unittest
 import pathlib
+import sys
 import tempfile
 import xmldiff.main
 
@@ -78,12 +79,14 @@ class TestEmbedImage(unittest.TestCase):
                                     'expected an image, got "text"'):
             pybadges._embed_image('http://www.google.com/')
 
+    @unittest.skipIf(sys.platform.startswith("win"), "requires Unix filesystem")
     def test_svg_file_path(self):
         image_path = os.path.abspath(
             os.path.join(TEST_DIR, 'golden-images', 'build-failure.svg'))
         self.assertRegex(pybadges._embed_image(image_path),
                          r'^data:image/svg(\+xml)?;base64,')
 
+    @unittest.skipIf(sys.platform.startswith("win"), "requires Unix filesystem")
     def test_png_file_path(self):
         with tempfile.NamedTemporaryFile() as png:
             png.write(PNG_IMAGE)
@@ -91,6 +94,7 @@ class TestEmbedImage(unittest.TestCase):
             self.assertEqual(pybadges._embed_image(png.name),
                              'data:image/png;base64,' + PNG_IMAGE_B64)
 
+    @unittest.skipIf(sys.platform.startswith("win"), "requires Unix filesystem")
     def test_unknown_type_file_path(self):
         with tempfile.NamedTemporaryFile() as non_image:
             non_image.write(b'Hello')
@@ -99,6 +103,7 @@ class TestEmbedImage(unittest.TestCase):
                                         'not able to determine file type'):
                 pybadges._embed_image(non_image.name)
 
+    @unittest.skipIf(sys.platform.startswith("win"), "requires Unix filesystem")
     def test_text_file_path(self):
         with tempfile.NamedTemporaryFile(suffix='.txt') as non_image:
             non_image.write(b'Hello')


### PR DESCRIPTION
**Environment:**

- Windows 10 Pro
- Python 3.8.3

**Problem:**

- Several unit tests were failing after making the clean setup. 
- The first problem was, that the badge generated by the script had attributes in a different order than badge from the existing one. The comparison was done by comparing their strings
- The second issue is that the method call `urllib.parse.urlparse(url)`  in `pybadges._embed_image`  parse the windows path with <letter driver> schema (eg for path C:\Users\kkapka\something, `urlparse` method identifies `C` as a schema which causes an error, that this schema is not supported)

**Solution:**

- compare two badges as text with `xmldiff` library. That lib solves the problem with attributes order
- skip windows incompatible tests

**Results:**

- All tests should pass both on Linux and Windows