### PR TITLE
Fixed typo "wholelink" in badge template

### DIFF
--- a/pybadges/badge-template-full.svg
+++ b/pybadges/badge-template-full.svg
@@ -41,7 +41,7 @@
     <text x="{{ (left_width+right_width/2-1)*10 }}" y="140" transform="scale(0.1)" textLength="{{ (right_width-10)*10 }}" lengthAdjust="spacing">{{ right_text}}</text>
 
   {% if left_link or whole_link %}
-    <a xlink:href="{{ left_link or wholelink }}">
+    <a xlink:href="{{ left_link or whole_link }}">
       <rect width="{{ left_width }}" height="20" fill="rgba(0,0,0,0)"/>
     </a>
   {% endif %}


### PR DESCRIPTION
Hello! I noticed that there was a small typo in `badge-template-full.svg`. 

I think that line 44
 `<a xlink:href="{{ left_link or wholelink }}">`
Should instead be
 `<a xlink:href="{{ left_link or whole_link }}">`

I have fixed the related golden images to reflect this change. Thank you!
